### PR TITLE
Fix overlays position to be relative to the viewport

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -1,9 +1,9 @@
 .overlay {
-    position:absolute;
+    position: fixed;
     background-color: #0000FF64;
 }
 
 .boundingRect {
-    position: absolute;
+    position: fixed;
     border: 3px dashed #ff0000a8;
 }


### PR DESCRIPTION
Set explicitely the overlay position to be "fixed" as the damage rectangles we obtain are relative to the browser viewport, not the body of the document (that could have a scroll).